### PR TITLE
Add Claude 4.5-driven character system prompt generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,7 +328,7 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
                                 <p class="text-sm">No thumbnail</p>
                             </div>
                         </div>
-                        <input type="text" id="charDescription" placeholder="Describe character appearance for image generation..." 
+                        <input type="text" id="charAppearance" placeholder="Describe character appearance for thumbnail generation..." 
                             class="w-full px-4 py-3 rounded-lg text-sm mb-2">
                         <button id="generateThumbnailBtn" class="w-full py-2 btn-secondary rounded-lg text-sm font-medium flex items-center justify-center gap-2">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -337,14 +337,35 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
                             Generate Thumbnail
                         </button>
                     </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-400 mb-2">Description / Personality *</label>
+                        <textarea id="charDescription" rows="4"
+                            class="w-full px-4 py-3 rounded-lg text-sm resize-y"
+                            placeholder="Describe the character's personality, speaking style, goals, boundaries, and vibe..."></textarea>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-400 mb-2">Background / Other Details (optional)</label>
+                        <textarea id="charBackground" rows="3"
+                            class="w-full px-4 py-3 rounded-lg text-sm resize-y"
+                            placeholder="Backstory, lore, relationships, setting details, kinks/preferences, etc."></textarea>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-400 mb-2">User Info and Description *</label>
+                        <textarea id="charUserInfo" rows="3"
+                            class="w-full px-4 py-3 rounded-lg text-sm resize-y"
+                            placeholder="Describe the user persona this character should interact with (name, tone, role, context, preferences)."></textarea>
+                    </div>
                     
                     <div>
-                        <label class="block text-sm font-medium text-gray-400 mb-2">System Prompt *</label>
+                        <label class="block text-sm font-medium text-gray-400 mb-2">System Prompt</label>
                         <textarea id="charSystemPrompt" rows="8" 
                             class="w-full px-4 py-3 rounded-lg text-sm resize-none"
-                            placeholder="Describe your character's personality, behavior, and how they should respond..."></textarea>
+                            placeholder="Generated automatically with Claude 4.5 Sonnet when you save a new character. You can edit it later."></textarea>
                         <p class="text-xs text-gray-500 mt-1">
-                            Tip: Include instructions for image generation at the end using ---IMAGE_PROMPT START--- and ---IMAGE_PROMPT END---
+                            New characters: prompt is generated from the fields above via OpenRouter (Claude 4.5 Sonnet).
                         </p>
                     </div>
                 </div>

--- a/js/dom.js
+++ b/js/dom.js
@@ -40,7 +40,10 @@ export const elements = {
     charName: document.getElementById('charName'),
     charAvatar: document.getElementById('charAvatar'),
     charSystemPrompt: document.getElementById('charSystemPrompt'),
+    charAppearance: document.getElementById('charAppearance'),
     charDescription: document.getElementById('charDescription'),
+    charBackground: document.getElementById('charBackground'),
+    charUserInfo: document.getElementById('charUserInfo'),
     thumbnailPreview: document.getElementById('thumbnailPreview'),
     generateThumbnailBtn: document.getElementById('generateThumbnailBtn'),
     


### PR DESCRIPTION
### Motivation
- Make character creation produce high-quality, consistent system prompts automatically from user-provided character data instead of requiring manual prompt authoring. 
- Capture richer character metadata (personality, background, user profile) so generated prompts can be tailored and reusable. 

### Description
- Added new form fields to the character modal to collect `Description / Personality`, `Background / Other Details`, `User Info and Description`, and a separate `Appearance` field used for thumbnail generation (`index.html`).
- Exposed new DOM refs for the added inputs (`charAppearance`, `charDescription`, `charBackground`, `charUserInfo`) in `js/dom.js` and wired them into the modal initialization and save/edit flows in `js/characters.js`.
- Implemented `generateCharacterSystemPrompt(...)` in `js/api-openrouter.js` which calls OpenRouter with the `anthropic/claude-sonnet-4.5` model to produce a production-ready system prompt from the collected fields, returning only the prompt text.
- Updated `saveCharacter` in `js/characters.js` to validate required fields, auto-generate the system prompt via `generateCharacterSystemPrompt` when the system prompt textarea is empty for new characters, persist the new metadata (`description`, `background`, `userInfo`, `appearance`), and keep manual editing available.
- Split the thumbnail input into a dedicated `appearance` input and updated thumbnail generation to use that field and keep existing thumbnail preview/storage behavior.

### Testing
- Syntax checks: ran `node --check js/characters.js`, `node --check js/api-openrouter.js`, and `node --check js/dom.js`, all succeeded. 
- UI smoke tests: served the app with `python3 -m http.server` and executed an automated Playwright script to open the character modal and capture a screenshot, which completed successfully.
- Basic runtime check: verified the app loads the modified JS files in a local browser automation session and no runtime parse errors were observed during the smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990426affbc832c9b7f99bec0d0b627)