### PR TITLE
Rework UI/UX and unify behavior across chat, character, and model flows

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+
+:root {
+    --bg-0: #07070b;
+    --bg-1: #10111a;
+    --bg-2: #17182a;
+    --surface: rgba(18, 20, 33, 0.72);
+    --surface-strong: rgba(22, 25, 40, 0.9);
+    --border: rgba(152, 103, 255, 0.22);
+    --border-strong: rgba(236, 72, 153, 0.35);
+    --text-0: #f5f3ff;
+    --text-1: #d5d3e5;
+    --text-2: #9e9bb7;
+    --brand-0: #8b5cf6;
+    --brand-1: #ec4899;
+    --brand-2: #f97316;
+    --ok: #22c55e;
+    --muted: #6b7280;
+    --danger: #ef4444;
+}
 
 * {
     margin: 0;
@@ -6,243 +25,188 @@
     box-sizing: border-box;
 }
 
+html,
+body {
+    height: 100%;
+}
+
 body {
     font-family: 'Inter', sans-serif;
-    background: linear-gradient(135deg, #0a0a0a 0%, #1a0a1a 50%, #0a0a1a 100%);
-    min-height: 100vh;
-    color: #e5e5e5;
+    background:
+        radial-gradient(1200px 700px at 88% -12%, rgba(236, 72, 153, 0.24), transparent 70%),
+        radial-gradient(1000px 700px at -8% 110%, rgba(124, 58, 237, 0.3), transparent 72%),
+        linear-gradient(165deg, var(--bg-0) 0%, var(--bg-1) 48%, #080812 100%);
+    color: var(--text-0);
+    letter-spacing: 0.01em;
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar {
-    width: 8px;
-}
-
-::-webkit-scrollbar-track {
-    background: #1a1a1a;
-}
-
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: #11131f; }
 ::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, #7c3aed, #dc2626);
-    border-radius: 4px;
+    background: linear-gradient(180deg, #8b5cf6, #ec4899);
+    border-radius: 8px;
 }
 
-::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(180deg, #a855f7, #ef4444);
+.glass {
+    background: var(--surface);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border: 1px solid var(--border);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
 }
 
-/* Glow effects */
-.glow-red {
-    box-shadow: 0 0 20px rgba(220, 38, 38, 0.3);
-}
-
-.glow-purple {
-    box-shadow: 0 0 20px rgba(124, 58, 237, 0.3);
-}
-
-/* Message animations */
-@keyframes slideInLeft {
-    from {
-        opacity: 0;
-        transform: translateX(-20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
-@keyframes slideInRight {
-    from {
-        opacity: 0;
-        transform: translateX(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-@keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
-}
-
-.message-ai {
-    animation: slideInLeft 0.3s ease-out;
-}
-
-.message-user {
-    animation: slideInRight 0.3s ease-out;
-}
-
-.fade-in {
-    animation: fadeIn 0.5s ease-out;
-}
-
-.loading-pulse {
-    animation: pulse 1.5s ease-in-out infinite;
-}
-
-/* Custom input styling */
-input, textarea, select {
-    background: rgba(26, 26, 26, 0.8);
-    border: 1px solid rgba(124, 58, 237, 0.3);
-    transition: all 0.3s ease;
-}
-
-input:focus, textarea:focus, select:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 10px rgba(124, 58, 237, 0.3);
-}
-
-/* Range slider styling */
-input[type="range"] {
-    -webkit-appearance: none;
-    appearance: none;
-    height: 6px;
-    background: linear-gradient(90deg, #7c3aed, #dc2626);
-    border-radius: 3px;
-    outline: none;
-}
-
-input[type="range"]::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 18px;
-    height: 18px;
-    background: linear-gradient(135deg, #a855f7, #ef4444);
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 0 10px rgba(168, 85, 247, 0.5);
-}
-
-input[type="range"]::-moz-range-thumb {
-    width: 18px;
-    height: 18px;
-    background: linear-gradient(135deg, #a855f7, #ef4444);
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: 0 0 10px rgba(168, 85, 247, 0.5);
-}
-
-/* Button hover effects */
 .btn-primary {
-    background: linear-gradient(135deg, #7c3aed 0%, #dc2626 100%);
-    transition: all 0.3s ease;
+    background: linear-gradient(135deg, var(--brand-0), var(--brand-1) 55%, var(--brand-2));
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #fff;
+    transition: 180ms ease;
 }
 
 .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(124, 58, 237, 0.4);
+    transform: translateY(-1px);
+    box-shadow: 0 12px 28px rgba(139, 92, 246, 0.34);
 }
 
 .btn-secondary {
-    background: rgba(124, 58, 237, 0.2);
-    border: 1px solid rgba(124, 58, 237, 0.5);
-    transition: all 0.3s ease;
+    background: rgba(139, 92, 246, 0.14);
+    border: 1px solid rgba(139, 92, 246, 0.35);
+    color: #ddd6fe;
+    transition: 180ms ease;
 }
 
 .btn-secondary:hover {
-    background: rgba(124, 58, 237, 0.3);
-    box-shadow: 0 0 15px rgba(124, 58, 237, 0.3);
+    background: rgba(139, 92, 246, 0.22);
+    border-color: rgba(236, 72, 153, 0.42);
 }
 
-/* Sidebar transition */
+input,
+textarea,
+select {
+    background: rgba(12, 14, 24, 0.9);
+    border: 1px solid rgba(139, 92, 246, 0.28);
+    color: var(--text-1);
+    transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+input::placeholder,
+textarea::placeholder {
+    color: var(--text-2);
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+    outline: none;
+    border-color: var(--border-strong);
+    box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.2);
+    background: rgba(16, 18, 30, 0.98);
+}
+
 #settingsPanel {
-    transition: transform 0.3s ease-in-out;
+    background: linear-gradient(180deg, rgba(12, 13, 23, 0.98), rgba(8, 9, 17, 0.98));
+    transition: transform 260ms ease;
 }
 
-/* Image container */
-.image-container {
-    position: relative;
-    overflow: hidden;
+#chatContainer {
+    scroll-behavior: smooth;
+}
+
+.character-card {
+    transition: all 180ms ease;
+    cursor: pointer;
     border-radius: 12px;
+    border: 1px solid rgba(139, 92, 246, 0.24);
+    background: rgba(23, 25, 39, 0.55);
+}
+
+.character-card:hover {
+    border-color: rgba(236, 72, 153, 0.4);
+    transform: translateY(-1px);
+    background: rgba(31, 34, 53, 0.85);
+}
+
+.character-card.active {
+    border-color: rgba(236, 72, 153, 0.62);
+    box-shadow: 0 0 0 1px rgba(236, 72, 153, 0.2), 0 10px 26px rgba(236, 72, 153, 0.16);
+    background: rgba(36, 24, 49, 0.78);
+}
+
+.image-container {
+    overflow: hidden;
+    border-radius: 14px;
+    border: 1px solid rgba(139, 92, 246, 0.22);
+    background: rgba(8, 9, 17, 0.8);
 }
 
 .image-container img {
-    transition: transform 0.3s ease;
+    transition: transform 220ms ease;
 }
 
 .image-container:hover img {
     transform: scale(1.02);
 }
 
-/* Loading spinner */
-.spinner {
-    width: 40px;
-    height: 40px;
-    border: 3px solid rgba(124, 58, 237, 0.3);
-    border-top-color: #a855f7;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
-/* Glass effect */
-.glass {
-    background: rgba(26, 26, 26, 0.7);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(124, 58, 237, 0.2);
-}
-
-/* Character card styles */
-.character-card {
-    transition: all 0.3s ease;
-    cursor: pointer;
-}
-
-.character-card:hover {
-    transform: translateX(4px);
-    border-color: rgba(124, 58, 237, 0.5);
-    background: rgba(124, 58, 237, 0.1);
-}
-
-.character-card.active {
-    border-color: #7c3aed;
-    background: rgba(124, 58, 237, 0.2);
-    box-shadow: 0 0 20px rgba(124, 58, 237, 0.3);
-}
-
-.character-card img {
-    transition: transform 0.3s ease;
-}
-
-.character-card:hover img {
-    transform: scale(1.05);
-}
-
-/* Modal styles */
 .modal-overlay {
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(3, 4, 10, 0.72);
     backdrop-filter: blur(4px);
 }
 
-/* Thumbnail preview styles */
-#thumbnailPreview {
-    transition: all 0.3s ease;
-}
-
-#thumbnailPreview img {
-    transition: opacity 0.3s ease;
-}
-
-/* Animate spin for loading */
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
-.animate-spin {
+.spinner {
+    width: 34px;
+    height: 34px;
+    border: 3px solid rgba(139, 92, 246, 0.24);
+    border-top-color: rgba(236, 72, 153, 0.95);
+    border-radius: 9999px;
     animation: spin 1s linear infinite;
 }
 
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@keyframes slideInLeft {
+    from { opacity: 0; transform: translateX(-16px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes slideInRight {
+    from { opacity: 0; transform: translateX(16px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: .45; }
+}
+
+.message-ai { animation: slideInLeft 200ms ease; }
+.message-user { animation: slideInRight 200ms ease; }
+.loading-pulse { animation: pulse 1.1s ease-in-out infinite; }
+.fade-in { animation: fadeIn 300ms ease; }
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.app-shell {
+    border: 1px solid rgba(139, 92, 246, 0.22);
+    border-radius: 18px;
+    margin: 10px;
+    overflow: hidden;
+    height: calc(100vh - 20px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 1024px) {
+    .app-shell {
+        border-radius: 0;
+        margin: 0;
+        height: 100vh;
+        border: none;
+    }
+
+    #settingsPanel {
+        position: fixed;
+        z-index: 60;
+        height: 100vh;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -10,14 +10,14 @@
 </head>
 
 <body class="overflow-hidden">
-    <div class="flex h-screen">
+    <div class="flex app-shell">
         <!-- Settings Panel (Sidebar) -->
         <aside id="settingsPanel"
-            class="w-96 bg-black/90 border-r border-purple-900/30 overflow-y-auto flex-shrink-0 transform translate-x-0">
+            class="w-96 border-r border-purple-900/30 overflow-y-auto flex-shrink-0 transform -translate-x-full lg:translate-x-0">
             <div class="p-6">
                 <h1
                     class="text-2xl font-bold bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 bg-clip-text text-transparent mb-6">
-                    ⚙️ Settings
+                    Control Center
                 </h1>
 
                 <!-- Characters Section -->
@@ -84,7 +84,7 @@
                                     d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15">
                                 </path>
                             </svg>
-                            Fetch OpenRouter Models
+                            Load OpenRouter Models
                         </button>
                     </div>
                 </div>
@@ -114,7 +114,7 @@
                                     d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15">
                                 </path>
                             </svg>
-                            Fetch Models
+                            Load Models
                         </button>
 
                         <div>
@@ -199,7 +199,7 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
                 <!-- Action Buttons -->
                 <div class="space-y-3">
                     <button id="saveSettingsBtn" class="w-full py-3 btn-primary rounded-xl font-semibold">
-                        Save Settings
+                        Save Preferences
                     </button>
                     <button id="clearChatBtn"
                         class="w-full py-2 bg-red-900/30 hover:bg-red-900/50 border border-red-700/50 rounded-xl font-medium text-red-400 transition-all flex items-center justify-center gap-2">
@@ -208,7 +208,7 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
                                 d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16">
                             </path>
                         </svg>
-                        Clear Chat
+                        Clear Conversation
                     </button>
                 </div>
             </div>
@@ -228,10 +228,10 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
                     <div>
                         <h1
                             class="text-2xl font-bold bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 bg-clip-text text-transparent">
-                            💋 EroChat + SwarmUI
+                            EroChat Studio
                         </h1>
                         <div id="currentCharacterDisplay" class="text-sm text-gray-400 flex items-center gap-2">
-                            <span>Talking to:</span>
+                            <span>Active character:</span>
                             <span id="currentCharacterName" class="text-pink-400 font-medium">Default Character</span>
                         </div>
                     </div>
@@ -309,7 +309,7 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
             <!-- Input Area -->
             <div class="glass border-t border-purple-900/30 p-4">
                 <div class="max-w-4xl mx-auto flex gap-3">
-                    <textarea id="messageInput" rows="1" placeholder="Type your message... (Press Enter to send)"
+                    <textarea id="messageInput" rows="1" placeholder="Write your message… (Enter to send, Shift+Enter for new line)"
                         class="flex-1 px-5 py-3 rounded-xl resize-none overflow-hidden"
                         style="min-height: 48px; max-height: 150px;"></textarea>
                     <button id="sendBtn" class="px-6 py-3 btn-primary rounded-xl font-semibold flex items-center gap-2">

--- a/js/api-openrouter.js
+++ b/js/api-openrouter.js
@@ -6,6 +6,7 @@ let fetchedModels = [];
 // Filter and populate models based on search query
 function filterAndPopulateModels(searchQuery = '') {
     const query = searchQuery.toLowerCase().trim();
+    const previousValue = elements.openrouterModel.value;
 
     // Clear current options
     elements.openrouterModel.innerHTML = '<option value="">Select a model...</option>';
@@ -25,6 +26,11 @@ function filterAndPopulateModels(searchQuery = '') {
         option.textContent = `${model.name} (${model.id})`;
         elements.openrouterModel.appendChild(option);
     });
+
+
+    if (previousValue && filteredModels.some(model => model.id === previousValue)) {
+        elements.openrouterModel.value = previousValue;
+    }
 
     // Update select label to show filter results
     if (query && filteredModels.length > 0) {
@@ -95,7 +101,7 @@ export async function fetchOpenRouterModels(silent = false) {
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
             </svg>
-            Fetch OpenRouter Models
+            Load OpenRouter Models
         `;
     }
 }

--- a/js/api-swarmui.js
+++ b/js/api-swarmui.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { elements } from './dom.js';
-import { updateConnectionStatus } from './utils.js';
+import { updateConnectionStatus, normalizeBaseUrl } from './utils.js';
 
 // Helper function to parse models from SwarmUI response
 function parseModels(data) {
@@ -45,7 +45,7 @@ function parseModels(data) {
 // Fetch available models from SwarmUI
 export async function fetchSwarmModels(silent = false) {
     if (typeof silent !== 'boolean') silent = false;
-    const url = elements.swarmUrl.value;
+    const url = normalizeBaseUrl(elements.swarmUrl.value);
 
     try {
         elements.fetchModelsBtn.disabled = true;
@@ -129,14 +129,14 @@ export async function fetchSwarmModels(silent = false) {
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
             </svg>
-            Fetch Models
+            Load Models
         `;
     }
 }
 
 // Get new session from SwarmUI
 export async function getSwarmSession() {
-    const url = elements.swarmUrl.value;
+    const url = normalizeBaseUrl(elements.swarmUrl.value);
 
     try {
         const response = await fetch(`${url}/API/GetNewSession`, {
@@ -160,8 +160,8 @@ export async function getSwarmSession() {
 }
 
 // Generate image using SwarmUI
-export async function generateImage(prompt) {
-    const url = elements.swarmUrl.value;
+export async function generateImage(prompt, width = null, height = null) {
+    const url = normalizeBaseUrl(elements.swarmUrl.value);
 
     try {
         elements.imageIndicator.classList.remove('hidden');
@@ -180,8 +180,8 @@ export async function generateImage(prompt) {
                 prompt: prompt,
                 negativeprompt: " (bad quality:1.15), (worst quality:1.3)",
                 model: elements.swarmModel.value,
-                width: parseInt(elements.imgWidth.value),
-                height: parseInt(elements.imgHeight.value),
+                width: width ? parseInt(width) : parseInt(elements.imgWidth.value),
+                height: height ? parseInt(height) : parseInt(elements.imgHeight.value),
                 steps: parseInt(elements.steps.value),
                 cfgscale: parseFloat(elements.cfgScale.value),
                 sampler_name: elements.sampler.value,
@@ -210,8 +210,8 @@ export async function generateImage(prompt) {
                     images: 1,
                     prompt: prompt,
                     model: elements.swarmModel.value,
-                    width: parseInt(elements.imgWidth.value),
-                    height: parseInt(elements.imgHeight.value),
+                    width: width ? parseInt(width) : parseInt(elements.imgWidth.value),
+                    height: height ? parseInt(height) : parseInt(elements.imgHeight.value),
                     steps: parseInt(elements.steps.value),
                     cfgscale: parseFloat(elements.cfgScale.value),
                     sampler_name: elements.sampler.value,

--- a/js/characters.js
+++ b/js/characters.js
@@ -10,10 +10,17 @@ let editingCharacterId = null;
 
 // Get current character
 export function getCurrentCharacter() {
-    if (state.currentCharacterId === 'default') {
-        return defaultCharacter;
-    }
-    return state.characters.find(c => c.id === state.currentCharacterId) || defaultCharacter;
+    const selected = state.characters.find(c => c.id === state.currentCharacterId);
+    if (selected) return selected;
+
+    const storedDefault = state.characters.find(c => c.id === 'default');
+    if (storedDefault) return storedDefault;
+
+    return {
+        ...defaultCharacter,
+        systemPrompt: state.settings.systemPrompt || defaultCharacter.systemPrompt,
+        messages: state.messages || []
+    };
 }
 
 // Render characters list in sidebar
@@ -95,6 +102,10 @@ export function selectCharacter(charId) {
     import('./messages.js').then(m => m.renderMessages());
 
     saveToLocalStorage();
+
+    if (window.innerWidth < 1024) {
+        import('./ui.js').then(ui => ui.toggleSidebar(false));
+    }
 }
 
 // Update current character UI elements

--- a/js/events.js
+++ b/js/events.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { elements } from './dom.js';
 import { toggleSidebar, autoResizeTextarea } from './ui.js';
+import { normalizeBaseUrl } from './utils.js';
 import { openCharacterModal, closeCharacterModal, saveCharacter, generateThumbnail, generateSystemPromptOnDemand } from './characters.js';
 import { fetchSwarmModels } from './api-swarmui.js';
 import { fetchOpenRouterModels, setupModelSearch } from './api-openrouter.js';
@@ -50,12 +51,20 @@ export function setupEventListeners() {
         }
     });
 
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth >= 1024) {
+            elements.settingsPanel.classList.remove('-translate-x-full');
+            elements.overlay.classList.add('hidden');
+        }
+    });
+
     // Save settings
     elements.saveSettingsBtn.addEventListener('click', () => {
         state.settings = {
             openrouterKey: elements.openrouterKey.value,
             openrouterModel: elements.openrouterModel.value,
-            swarmUrl: elements.swarmUrl.value,
+            swarmUrl: normalizeBaseUrl(elements.swarmUrl.value),
             swarmModel: elements.swarmModel.value,
             imgWidth: parseInt(elements.imgWidth.value),
             imgHeight: parseInt(elements.imgHeight.value),

--- a/js/main.js
+++ b/js/main.js
@@ -43,6 +43,8 @@ export async function sendMessage() {
     // Show typing indicator
     elements.typingIndicator.classList.remove('hidden');
     state.isGenerating = true;
+    elements.sendBtn.disabled = true;
+    elements.sendBtn.classList.add('opacity-60', 'cursor-not-allowed');
 
     try {
         // Get current character's system prompt
@@ -123,6 +125,8 @@ export async function sendMessage() {
 
     } finally {
         state.isGenerating = false;
+        elements.sendBtn.disabled = false;
+        elements.sendBtn.classList.remove('opacity-60', 'cursor-not-allowed');
     }
 }
 

--- a/js/messages.js
+++ b/js/messages.js
@@ -79,7 +79,7 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
     const character = getCurrentCharacter();
     const messageId = id || generateId();
     const messageDiv = document.createElement('div');
-    messageDiv.className = 'message-ai max-w-5xl';
+    messageDiv.className = 'message-ai max-w-6xl';
     messageDiv.id = messageId;
     
     // Remove the image prompt block from display
@@ -88,7 +88,7 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
     let imageSection = '';
     if (imageUrl) {
         imageSection = `
-            <div class="w-1/3 flex-shrink-0">
+            <div class="w-full lg:w-1/3 flex-shrink-0">
                 <div class="image-container h-full">
                     <img src="${imageUrl}" alt="Generated" class="w-full h-full object-cover rounded-xl shadow-2xl" style="max-height: 400px;">
                 </div>
@@ -97,7 +97,7 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
     } else if (content.includes('---IMAGE_PROMPT')) {
         // Image is being generated
         imageSection = `
-            <div class="w-1/3 flex-shrink-0">
+            <div class="w-full lg:w-1/3 flex-shrink-0">
                 <div class="image-container bg-gray-900/50 rounded-xl p-8 flex items-center justify-center h-full" style="min-height: 300px;">
                     <div class="text-center">
                         <div class="spinner mx-auto mb-3"></div>
@@ -115,15 +115,15 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
             <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-red-500 flex items-center justify-center flex-shrink-0">
                 <span class="text-xl">${character.avatar}</span>
             </div>
-            <div class="flex-1 flex gap-4 ${hasImage ? 'flex-row' : 'flex-col'}">
-                <div class="glass rounded-2xl rounded-tl-none px-5 py-4 ${hasImage ? 'w-2/3' : 'w-full'}">
+            <div class="flex-1 flex gap-4 ${hasImage ? 'flex-col lg:flex-row' : 'flex-col'}">
+                <div class="glass rounded-2xl rounded-tl-none px-5 py-4 ${hasImage ? 'w-full lg:w-2/3' : 'w-full'}">
                     <p class="text-gray-300 leading-relaxed">${formatMessage(escapeHtml(displayContent))}</p>
                 </div>
                 ${imageSection}
             </div>
         </div>
         ${hasImage ? `
-        <div class="flex gap-2 mt-2 ml-13 pl-13">
+        <div class="flex gap-2 mt-2 ml-12 pl-1">
             <button onclick="window.regenerateImage('${messageId}')" class="text-xs text-gray-500 hover:text-pink-400 flex items-center gap-1 transition-colors">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,9 +1,15 @@
 import { elements } from './dom.js';
 
 // Toggle sidebar visibility (mobile)
-export function toggleSidebar() {
-    elements.settingsPanel.classList.toggle('-translate-x-full');
-    elements.overlay.classList.toggle('hidden');
+export function toggleSidebar(forceOpen = null) {
+    if (window.innerWidth >= 1024) return;
+
+    const shouldOpen = forceOpen !== null
+        ? forceOpen
+        : elements.settingsPanel.classList.contains('-translate-x-full');
+
+    elements.settingsPanel.classList.toggle('-translate-x-full', !shouldOpen);
+    elements.overlay.classList.toggle('hidden', !shouldOpen);
 }
 
 // Auto-resize textarea as user types

--- a/js/utils.js
+++ b/js/utils.js
@@ -32,3 +32,9 @@ export function updateConnectionStatus(connected) {
         text.className = 'text-gray-400';
     }
 }
+
+
+// Normalize base URL by trimming spaces and trailing slash
+export function normalizeBaseUrl(url) {
+    return (url || '').trim().replace(/\/$/, '');
+}


### PR DESCRIPTION
### Motivation
- Make the UI cohesive and responsive with a modern visual system and consistent interaction patterns across desktop and mobile.
- Fix state inconsistencies introduced by multiple agents (character selection, default character fallback, and persisted system prompts/messages).
- Improve the image generation and model-selection UX to be more robust and predictable for both SwarmUI and OpenRouter integrations.

### Description
- Visual / layout: redesigned styles in `css/styles.css` and updated `index.html` to add a framed responsive shell, refined controls/labels, and improved composer hints and button labels (e.g. `Save Preferences`, `Load Models`).
- Character state: made `getCurrentCharacter()` resilient to missing/persisted entries and ensured the settings `systemPrompt` and `messages` fall back to current state when needed (`js/characters.js`).
- Mobile UX & sidebar: sidebar is now mobile-only toggled with deterministic `toggleSidebar(forceOpen)` behavior; selecting a character closes the sidebar on small screens and window resize normalizes sidebar state (`js/ui.js`, `js/events.js`, `js/characters.js`).
- Messages & layout: improved chat layout for mixed text+image replies so image previews stack on small screens and split on large screens, and adjusted spacing/controls for regenerate actions (`js/messages.js`).
- SwarmUI/OpenRouter integration: added `normalizeBaseUrl()` helper and applied URL normalization when saving/using the SwarmUI URL; preserved selected OpenRouter model when filtering the model list; added optional `width`/`height` parameters to `generateImage()` for thumbnail generation (`js/utils.js`, `js/events.js`, `js/api-swarmui.js`, `js/api-openrouter.js`).
- Interaction polish: disable the send button while a message is generating and restore it afterward to prevent duplicate requests (`js/main.js`).

### Testing
- Ran syntax checks on all JS files with `for f in js/*.js; do node --check "$f"; done` and they passed (`JS syntax OK`).
- Launched a static server with `python -m http.server 8080` and loaded the app to validate runtime wiring (server started successfully in the environment). 
- Attempted an automated UI screenshot using Playwright, but the headless Chromium crashed (SIGSEGV) in this environment so capture failed; this is an environment-specific issue and not a functional failure of the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990539654e4832c8ce36ed1a4b1ac04)