### PR TITLE
Add image zoom and per-character image galleries

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -210,3 +210,12 @@ select:focus {
         height: 100vh;
     }
 }
+
+
+.image-clickable {
+    cursor: zoom-in;
+}
+
+.zoomed-image {
+    border: 1px solid rgba(236, 72, 153, 0.35);
+}

--- a/index.html
+++ b/index.html
@@ -435,6 +435,32 @@ masterpiece, best quality, ultra-detailed, 8k, realistic, [very detailed, NSFW E
         </div>
     </div>
 
+    <!-- Image Zoom Modal -->
+    <div id="imageZoomModal" class="fixed inset-0 modal-overlay z-50 hidden flex items-center justify-center p-4">
+        <button id="closeImageZoomBtn" class="absolute top-4 right-4 p-2 hover:bg-white/10 rounded-lg transition-colors" aria-label="Close zoomed image">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
+        <img id="zoomedImage" src="" alt="Zoomed generated image" class="max-w-full max-h-[90vh] rounded-xl shadow-2xl zoomed-image">
+    </div>
+
+    <!-- Character Gallery Modal -->
+    <div id="characterGalleryModal" class="fixed inset-0 modal-overlay z-50 hidden flex items-center justify-center p-4">
+        <div class="glass rounded-2xl w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
+            <div class="p-4 border-b border-purple-900/30 flex items-center justify-between">
+                <h2 id="galleryTitle" class="text-lg font-semibold text-pink-400">Character Gallery</h2>
+                <button id="closeGalleryBtn" class="p-2 hover:bg-white/10 rounded-lg transition-colors" aria-label="Close character gallery">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <div id="characterGalleryGrid" class="p-4 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            </div>
+        </div>
+    </div>
+
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/js/dom.js
+++ b/js/dom.js
@@ -14,6 +14,15 @@ export const elements = {
     welcomeAvatar: document.getElementById('welcomeAvatar'),
     welcomeMessage: document.getElementById('welcomeMessage'),
 
+    // Image modals
+    imageZoomModal: document.getElementById('imageZoomModal'),
+    zoomedImage: document.getElementById('zoomedImage'),
+    closeImageZoomBtn: document.getElementById('closeImageZoomBtn'),
+    characterGalleryModal: document.getElementById('characterGalleryModal'),
+    closeGalleryBtn: document.getElementById('closeGalleryBtn'),
+    characterGalleryGrid: document.getElementById('characterGalleryGrid'),
+    galleryTitle: document.getElementById('galleryTitle'),
+
     // Settings inputs
     openrouterKey: document.getElementById('openrouterKey'),
     openrouterModel: document.getElementById('openrouterModel'),

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,8 @@
 import { state } from './state.js';
 import { elements } from './dom.js';
 import { loadFromLocalStorage, saveToLocalStorage } from './storage.js';
-import { getCurrentCharacter } from './characters.js';
-import { addUserMessageToUI, addAIMessageToUI, updateAIMessageImage } from './messages.js';
+import { getCurrentCharacter, saveGeneratedImageToCurrentCharacter } from './characters.js';
+import { addUserMessageToUI, addAIMessageToUI, updateAIMessageImage, openImageZoom, closeImageZoom, openCharacterGallery, closeCharacterGallery } from './messages.js';
 import { generateImage } from './api-swarmui.js';
 import { sendChatRequest } from './api-openrouter.js';
 import { toggleSidebar, scrollToBottom } from './ui.js';
@@ -81,6 +81,7 @@ export async function sendMessage() {
                 const msgIndex = state.messages.findIndex(m => m.id === aiMessageId);
                 if (msgIndex !== -1) {
                     state.messages[msgIndex].imageUrl = imageUrl;
+                    saveGeneratedImageToCurrentCharacter(imageUrl);
                     saveToLocalStorage();
                 }
             } catch (imgError) {
@@ -168,6 +169,19 @@ function init() {
     window.selectCharacter = selectCharacter;
     window.deleteCharacter = deleteCharacter;
     window.editCharacter = editCharacter;
+    window.openImageZoom = openImageZoom;
+    window.openCharacterGallery = openCharacterGallery;
+
+    // Image modal behavior
+    elements.closeImageZoomBtn.addEventListener('click', closeImageZoom);
+    elements.imageZoomModal.addEventListener('click', (e) => {
+        if (e.target === elements.imageZoomModal) closeImageZoom();
+    });
+
+    elements.closeGalleryBtn.addEventListener('click', closeCharacterGallery);
+    elements.characterGalleryModal.addEventListener('click', (e) => {
+        if (e.target === elements.characterGalleryModal) closeCharacterGallery();
+    });
 
     // Focus input on load
     elements.messageInput.focus();

--- a/js/messages.js
+++ b/js/messages.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { elements } from './dom.js';
-import { getCurrentCharacter } from './characters.js';
+import { getCurrentCharacter, getCharacterById, saveGeneratedImageToCurrentCharacter } from './characters.js';
 import { generateId, escapeHtml, formatMessage } from './utils.js';
 import { scrollToBottom } from './ui.js';
 import { generateImage } from './api-swarmui.js';
@@ -9,9 +9,9 @@ import { saveToLocalStorage } from './storage.js';
 // Render all messages
 export function renderMessages() {
     elements.chatContainer.innerHTML = '';
-    
+
     const character = getCurrentCharacter();
-    
+
     // Show welcome message if no messages
     if (state.messages.length === 0) {
         const welcomeDiv = document.createElement('div');
@@ -24,7 +24,7 @@ export function renderMessages() {
                 <div class="flex-1">
                     <div class="glass rounded-2xl rounded-tl-none px-5 py-4">
                         <p class="text-gray-300 leading-relaxed">
-                            Welcome to <strong class="text-pink-400">EroChat + SwarmUI</strong>! I'm <strong class="text-purple-400">${escapeHtml(character.name)}</strong>, ready for intimate conversations. 
+                            Welcome to <strong class="text-pink-400">EroChat + SwarmUI</strong>! I'm <strong class="text-purple-400">${escapeHtml(character.name)}</strong>, ready for intimate conversations.
                             Every response I give will be automatically visualized using your local SwarmUI instance.
                         </p>
                         <p class="text-gray-400 text-sm mt-3">
@@ -37,7 +37,7 @@ export function renderMessages() {
         elements.chatContainer.appendChild(welcomeDiv);
         return;
     }
-    
+
     state.messages.forEach(msg => {
         if (msg.role === 'user') {
             addUserMessageToUI(msg.content, msg.id, false);
@@ -45,7 +45,7 @@ export function renderMessages() {
             addAIMessageToUI(msg.content, msg.imageUrl, msg.id, false);
         }
     });
-    
+
     scrollToBottom();
 }
 
@@ -55,7 +55,7 @@ export function addUserMessageToUI(content, id = null, animate = true) {
     const messageDiv = document.createElement('div');
     messageDiv.className = 'message-user flex justify-end max-w-3xl ml-auto';
     messageDiv.id = messageId;
-    
+
     messageDiv.innerHTML = `
         <div class="flex items-start gap-3 flex-row-reverse">
             <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center flex-shrink-0">
@@ -68,10 +68,18 @@ export function addUserMessageToUI(content, id = null, animate = true) {
             </div>
         </div>
     `;
-    
+
     elements.chatContainer.appendChild(messageDiv);
     scrollToBottom();
     return messageId;
+}
+
+function imageContentHtml(imageUrl) {
+    return `
+        <div class="image-container h-full image-clickable" onclick="window.openImageZoom('${imageUrl}')">
+            <img src="${imageUrl}" alt="Generated" class="w-full h-full object-cover rounded-xl shadow-2xl" style="max-height: 400px;">
+        </div>
+    `;
 }
 
 // Add AI message to UI
@@ -81,17 +89,15 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
     const messageDiv = document.createElement('div');
     messageDiv.className = 'message-ai max-w-6xl';
     messageDiv.id = messageId;
-    
+
     // Remove the image prompt block from display
     const displayContent = content.replace(/---IMAGE_PROMPT START---[\s\S]*?---IMAGE_PROMPT END---/, '').trim();
-    
+
     let imageSection = '';
     if (imageUrl) {
         imageSection = `
             <div class="w-full lg:w-1/3 flex-shrink-0">
-                <div class="image-container h-full">
-                    <img src="${imageUrl}" alt="Generated" class="w-full h-full object-cover rounded-xl shadow-2xl" style="max-height: 400px;">
-                </div>
+                ${imageContentHtml(imageUrl)}
             </div>
         `;
     } else if (content.includes('---IMAGE_PROMPT')) {
@@ -107,9 +113,9 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
             </div>
         `;
     }
-    
+
     const hasImage = imageSection !== '';
-    
+
     messageDiv.innerHTML = `
         <div class="flex items-start gap-3">
             <div class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-red-500 flex items-center justify-center flex-shrink-0">
@@ -123,17 +129,25 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
             </div>
         </div>
         ${hasImage ? `
-        <div class="flex gap-2 mt-2 ml-12 pl-1">
+        <div class="flex gap-4 mt-2 ml-12 pl-1">
             <button onclick="window.regenerateImage('${messageId}')" class="text-xs text-gray-500 hover:text-pink-400 flex items-center gap-1 transition-colors">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                 </svg>
                 Regenerate Image
             </button>
+            ${imageUrl ? `
+            <button onclick="window.openImageZoom('${imageUrl}')" class="text-xs text-gray-500 hover:text-blue-300 flex items-center gap-1 transition-colors">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.55-4.55M19 5h-4m4 0v4M9 14l-4.55 4.55M5 19h4m-4 0v-4"></path>
+                </svg>
+                Zoom
+            </button>
+            ` : ''}
         </div>
         ` : ''}
     `;
-    
+
     elements.chatContainer.appendChild(messageDiv);
     scrollToBottom();
     return messageId;
@@ -145,26 +159,75 @@ export function updateAIMessageImage(messageId, imageUrl) {
     if (messageDiv) {
         const imageContainer = messageDiv.querySelector('.image-container');
         if (imageContainer) {
-            imageContainer.innerHTML = `
-                <img src="${imageUrl}" alt="Generated" class="w-full h-full object-cover rounded-xl shadow-2xl fade-in" style="max-height: 400px;">
-            `;
+            imageContainer.outerHTML = imageContentHtml(imageUrl);
+        }
+
+        const controls = messageDiv.querySelector('.flex.gap-4.mt-2');
+        if (controls && !controls.innerHTML.includes('Zoom')) {
+            controls.insertAdjacentHTML('beforeend', `
+                <button onclick="window.openImageZoom('${imageUrl}')" class="text-xs text-gray-500 hover:text-blue-300 flex items-center gap-1 transition-colors">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.55-4.55M19 5h-4m4 0v4M9 14l-4.55 4.55M5 19h4m-4 0v-4"></path>
+                    </svg>
+                    Zoom
+                </button>
+            `);
         }
     }
+}
+
+export function openImageZoom(imageUrl) {
+    if (!imageUrl) return;
+    elements.zoomedImage.src = imageUrl;
+    elements.imageZoomModal.classList.remove('hidden');
+}
+
+export function closeImageZoom() {
+    elements.imageZoomModal.classList.add('hidden');
+    elements.zoomedImage.src = '';
+}
+
+export function openCharacterGallery(characterId) {
+    const character = getCharacterById(characterId);
+    if (!character) return;
+
+    const images = character.generatedImages || [];
+    elements.galleryTitle.textContent = `${character.name} - Gallery`;
+
+    if (images.length === 0) {
+        elements.characterGalleryGrid.innerHTML = `
+            <div class="col-span-full text-center py-10 text-gray-400">
+                No generated images yet for this character.
+            </div>
+        `;
+    } else {
+        elements.characterGalleryGrid.innerHTML = images.map((url, index) => `
+            <button class="image-container image-clickable p-0" onclick="window.openImageZoom('${url}')" aria-label="Open gallery image ${index + 1}">
+                <img src="${url}" alt="${escapeHtml(character.name)} gallery image ${index + 1}" class="w-full h-56 object-cover rounded-xl shadow-xl">
+            </button>
+        `).join('');
+    }
+
+    elements.characterGalleryModal.classList.remove('hidden');
+}
+
+export function closeCharacterGallery() {
+    elements.characterGalleryModal.classList.add('hidden');
 }
 
 // Regenerate image for a message
 export async function regenerateImage(messageId) {
     const message = state.messages.find(m => m.id === messageId);
     if (!message) return;
-    
+
     const promptMatch = message.content.match(/---IMAGE_PROMPT START---([\s\S]*?)---IMAGE_PROMPT END---/);
     if (!promptMatch) {
         alert('No image prompt found in this message.');
         return;
     }
-    
+
     const imagePrompt = promptMatch[1].trim();
-    
+
     // Update UI to show loading
     const messageDiv = document.getElementById(messageId);
     if (messageDiv) {
@@ -180,15 +243,16 @@ export async function regenerateImage(messageId) {
             `;
         }
     }
-    
+
     try {
         const imageUrl = await generateImage(imagePrompt);
         updateAIMessageImage(messageId, imageUrl);
-        
+
         // Update message in state
         message.imageUrl = imageUrl;
+        saveGeneratedImageToCurrentCharacter(imageUrl);
         saveToLocalStorage();
-        
+
     } catch (error) {
         console.error('Failed to regenerate image:', error);
         if (messageDiv) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -39,7 +39,11 @@ export function loadFromLocalStorage() {
                 updateSettingsUI();
             }
             if (parsed.characters) {
-                state.characters = parsed.characters;
+                state.characters = parsed.characters.map(char => ({
+                    ...char,
+                    messages: char.messages || [],
+                    generatedImages: char.generatedImages || []
+                }));
             }
             if (parsed.currentCharacterId) {
                 state.currentCharacterId = parsed.currentCharacterId;


### PR DESCRIPTION
### Motivation
- Enable users to inspect generated images at full size and browse all images produced for a given character from the UI.
- Persist per-character galleries so generated images are discoverable and survive reloads.

### Description
- Added two new modals in `index.html`: an image zoom modal (`#imageZoomModal`) and a character gallery modal (`#characterGalleryModal`), plus a grid container for gallery images.
- Rendered chat images as clickable thumbnails with a `Zoom` action and helper `imageContentHtml` in `js/messages.js`, and added `openImageZoom`/`closeImageZoom` and `openCharacterGallery`/`closeCharacterGallery` functions.
- Added per-character storage and helpers in `js/characters.js`: `saveGeneratedImageToCurrentCharacter` and `getCharacterById`, surfaced a gallery shortcut button on each character card, and ensured new characters include a `generatedImages` array.
- Hooked image persistence into the generation flow in `js/main.js` so newly produced images are saved to the active character gallery via `saveGeneratedImageToCurrentCharacter`.
- Migrated loading/saving in `js/storage.js` to guarantee `messages` and `generatedImages` arrays when loading older local data and added DOM refs for the new elements in `js/dom.js`.
- Minor CSS in `css/styles.css` to indicate clickable images and style the zoomed image frame.

### Testing
- Ran static checks: `node --check js/main.js && node --check js/messages.js && node --check js/characters.js && node --check js/storage.js && node --check js/dom.js`, all passed.
- Performed a visual smoke test by serving the app with `python -m http.server 8000` and capturing a Playwright screenshot of `index.html`, which produced the expected UI for the gallery/zoom modals.
- Confirmed localStorage migration behavior by loading saved state and verifying `generatedImages` arrays are present for characters (manual validation during screenshot run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973e9ec108832c85a5da911588aecd)