### PR TITLE
Make image generation optional in chat flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ No build tools, no backend setup, no framework required.
 ## What it does
 
 - Chat with custom characters
-- Generate an image for each AI response
+- Generate an image for each AI response (optional toggle)
 - Create character thumbnails
 - Save chats and settings in your browser
 - Works on desktop and mobile layouts
@@ -46,12 +46,15 @@ Then open: `http://localhost:8080`
 2. Click **Fetch OpenRouter Models**
 3. Pick a model
 
-### SwarmUI
+### SwarmUI (optional)
 
-1. Make sure SwarmUI is running (default `http://localhost:7801`)
-2. Update Base URL if needed
-3. Click **Fetch Models**
-4. Pick a model
+1. Enable image generation if you want automatic images
+2. Make sure SwarmUI is running (default `http://localhost:7801`)
+3. Update Base URL if needed
+4. Click **Fetch Models**
+5. Pick a model
+
+If image generation is disabled, chat works without selecting a SwarmUI model.
 
 ## Characters
 

--- a/index.html
+++ b/index.html
@@ -138,6 +138,14 @@
                     </h2>
 
                     <div class="space-y-4">
+                        <label class="flex items-center justify-between gap-3 p-3 rounded-lg bg-black/20 border border-purple-900/30 cursor-pointer">
+                            <div>
+                                <p class="text-sm font-medium text-gray-300">Enable image generation</p>
+                                <p class="text-xs text-gray-500">When disabled, chat works without SwarmUI model selection.</p>
+                            </div>
+                            <input type="checkbox" id="enableImageGeneration" class="h-4 w-4" checked>
+                        </label>
+
                         <div class="grid grid-cols-2 gap-3">
                             <div>
                                 <label class="block text-sm font-medium text-gray-400 mb-2">Width</label>

--- a/js/config.js
+++ b/js/config.js
@@ -19,6 +19,7 @@ export const defaultSettings = {
     openrouterModel: 'anthropic/claude-3.5-sonnet',
     swarmUrl: 'http://localhost:7801',
     swarmModel: '',
+    enableImageGeneration: true,
     imgWidth: 832,
     imgHeight: 1216,
     steps: 25,

--- a/js/dom.js
+++ b/js/dom.js
@@ -20,6 +20,7 @@ export const elements = {
     openrouterModelSearch: document.getElementById('openrouterModelSearch'),
     swarmUrl: document.getElementById('swarmUrl'),
     swarmModel: document.getElementById('swarmModel'),
+    enableImageGeneration: document.getElementById('enableImageGeneration'),
     imgWidth: document.getElementById('imgWidth'),
     imgHeight: document.getElementById('imgHeight'),
     steps: document.getElementById('steps'),

--- a/js/events.js
+++ b/js/events.js
@@ -66,6 +66,7 @@ export function setupEventListeners() {
             openrouterModel: elements.openrouterModel.value,
             swarmUrl: normalizeBaseUrl(elements.swarmUrl.value),
             swarmModel: elements.swarmModel.value,
+            enableImageGeneration: elements.enableImageGeneration.checked,
             imgWidth: parseInt(elements.imgWidth.value),
             imgHeight: parseInt(elements.imgHeight.value),
             steps: parseInt(elements.steps.value),

--- a/js/main.js
+++ b/js/main.js
@@ -25,8 +25,8 @@ export async function sendMessage() {
         return;
     }
 
-    if (!elements.swarmModel.value) {
-        alert('Please select a SwarmUI model in settings.');
+    if (state.settings.enableImageGeneration !== false && !elements.swarmModel.value) {
+        alert('Please select a SwarmUI model in settings or disable image generation.');
         toggleSidebar();
         return;
     }
@@ -72,7 +72,7 @@ export async function sendMessage() {
         saveToLocalStorage();
 
         // Generate image if prompt exists
-        if (imagePrompt) {
+        if (state.settings.enableImageGeneration !== false && imagePrompt) {
             try {
                 const imageUrl = await generateImage(imagePrompt);
                 updateAIMessageImage(aiMessageId, imageUrl);

--- a/js/messages.js
+++ b/js/messages.js
@@ -94,7 +94,7 @@ export function addAIMessageToUI(content, imageUrl = null, id = null, animate = 
                 </div>
             </div>
         `;
-    } else if (content.includes('---IMAGE_PROMPT')) {
+    } else if (state.settings.enableImageGeneration !== false && content.includes('---IMAGE_PROMPT')) {
         // Image is being generated
         imageSection = `
             <div class="w-full lg:w-1/3 flex-shrink-0">

--- a/js/storage.js
+++ b/js/storage.js
@@ -92,6 +92,7 @@ export function updateSettingsUI() {
     elements.openrouterModel.value = state.settings.openrouterModel;
     elements.swarmUrl.value = state.settings.swarmUrl;
     elements.swarmModel.value = state.settings.swarmModel;
+    elements.enableImageGeneration.checked = state.settings.enableImageGeneration !== false;
     elements.imgWidth.value = state.settings.imgWidth;
     elements.imgHeight.value = state.settings.imgHeight;
     elements.steps.value = state.settings.steps;


### PR DESCRIPTION
### Motivation
- Users should be able to use chat without requiring image generation or selecting a SwarmUI model. 
- Avoid forcing a model selection and prevent the UI from showing a perpetual "Generating image..." state when images are disabled.

### Description
- Added an `Enable image generation` checkbox to the Generation settings UI and exposed it as `elements.enableImageGeneration` in `js/dom.js` and `index.html`.
- Persisted the toggle in settings via `defaultSettings.enableImageGeneration` (`js/config.js`) and wired save/load logic to include `enableImageGeneration` (`js/events.js`, `js/storage.js`).
- Updated send flow to only validate `swarmModel` and trigger `generateImage()` when `state.settings.enableImageGeneration` is enabled (`js/main.js`).
- Prevented the image placeholder from appearing when image generation is disabled by checking `state.settings.enableImageGeneration` in message rendering (`js/messages.js`).
- Updated `README.md` to document that SwarmUI/image generation is optional.

### Testing
- Ran static syntax/type checks with `node --check js/main.js && node --check js/messages.js && node --check js/events.js && node --check js/storage.js && node --check js/config.js && node --check js/dom.js` which completed without errors.
- Served the app with `python3 -m http.server 8080 --directory /workspace/EroChat` and loaded the page to verify the new toggle renders (screenshot captured), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c8ab2624832990c854dc7be6ddfc)