### PR TITLE
Improve mobile responsiveness for EroChat UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -196,6 +196,14 @@ select:focus {
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
 }
 
+#settingsPanel {
+    width: min(24rem, 100vw);
+}
+
+#messageInput {
+    min-height: 48px;
+}
+
 @media (max-width: 1024px) {
     .app-shell {
         border-radius: 0;
@@ -208,5 +216,77 @@ select:focus {
         position: fixed;
         z-index: 60;
         height: 100vh;
+        width: min(24rem, 100vw);
+    }
+}
+
+@media (max-width: 768px) {
+    body {
+        overflow: hidden;
+    }
+
+    #settingsPanel {
+        width: 100vw;
+    }
+
+    header {
+        padding: 0.85rem 1rem;
+    }
+
+    header h1 {
+        font-size: 1.25rem;
+        line-height: 1.4;
+    }
+
+    #currentCharacterDisplay {
+        font-size: 0.75rem;
+    }
+
+    #connectionStatus {
+        padding: 0.35rem 0.55rem;
+        font-size: 0.75rem;
+        gap: 0.35rem;
+    }
+
+    #chatContainer {
+        padding: 1rem;
+        gap: 1rem;
+    }
+
+    .message-ai,
+    .message-user {
+        max-width: 100%;
+    }
+
+    #typingIndicator,
+    #imageIndicator {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        padding-bottom: 0.75rem;
+    }
+
+    main > .glass.border-t {
+        padding: 0.75rem;
+        padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    }
+
+    main > .glass.border-t .max-w-4xl {
+        gap: 0.5rem;
+    }
+
+    #messageInput {
+        font-size: 0.95rem;
+        padding: 0.8rem 0.95rem;
+        max-height: 35vh !important;
+    }
+
+    #sendBtn {
+        min-width: 3rem;
+        padding: 0.75rem;
+        justify-content: center;
+    }
+
+    #sendBtn span {
+        display: none;
     }
 }


### PR DESCRIPTION
### Motivation
- The UI needs to behave well on narrow viewports so the settings drawer and chat composer are usable on phones and small tablets.
- Reduce horizontal overflow and improve spacing/typography for a clearer mobile experience without changing app behavior.

### Description
- Updated `css/styles.css` to constrain the desktop sidebar width with `#settingsPanel { width: min(24rem, 100vw); }` and give the composer a minimum height with `#messageInput { min-height: 48px; }`.
- Kept the sidebar fixed and clamped at tablet sizes via the existing `@media (max-width: 1024px)` rule to avoid overflow on narrower screens.
- Added a phone breakpoint `@media (max-width: 768px)` that applies full-width drawer behavior, tighter header paddings/typography, reduced status indicator sizing, full-width messages, adjusted chat paddings, safe-area bottom padding for the composer, and a compact icon-first send button by hiding the text label.
- Changes are CSS-only and do not modify JavaScript behavior or app logic.

### Testing
- Launched a local static server using `python3 -m http.server 4173` and confirmed the app served successfully.
- Ran a Playwright mobile viewport script against `http://127.0.0.1:4173` which completed and produced a mobile screenshot (`artifacts/mobile-home.png`).
- Verified the modified file `css/styles.css` contains the new mobile-specific rules and that the app renders without console errors in the automated load step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cd4cae308329bbe483938cfeb158)